### PR TITLE
Fixes array-to-object conversion notice

### DIFF
--- a/recursive-acf-to-wp-rest-api.php
+++ b/recursive-acf-to-wp-rest-api.php
@@ -28,7 +28,7 @@ function recursive_acf_register_acf() {
 }
 
 function recursive_acf_get_acf($object, $field_name, $request) {
-    return recursive_acf_get_fields($object->id);
+    return recursive_acf_get_fields($object['id']);
 }
 
 function recursive_acf_update_acf($values, $object, $field_name) {


### PR DESCRIPTION
Fixes the following notice:
```Notice: Trying to get property of non-object in /var/www/web/www/wp-content/plugins/recursive-acf-to-wp-rest-api.php on line 31```

WP version: `4.9.1`